### PR TITLE
Fixes to compile against the new libnetapi.so, radio search functionality restored, crashes fixed

### DIFF
--- a/HttpUtils.h
+++ b/HttpUtils.h
@@ -24,25 +24,6 @@
 #include <StringList.h>
 #include <Url.h>
 
-
-class HttpRequest : public BHttpRequest {
-public:
-	HttpRequest(const BUrl& url, bool ssl = false,
-		const char* protocolName = "HTTP",
-		BUrlProtocolListener* listener = NULL, BUrlContext* context = NULL)
-		:
-		BHttpRequest(url, ssl, protocolName, listener, context)
-	{};
-
-
-	virtual	BHttpResult&
-	Result() const
-	{
-		return (BHttpResult&)BHttpRequest::Result();
-	}
-};
-
-
 class HttpUtils {
 public:
 	static	status_t			CheckPort(BUrl url, BUrl* newUrl,

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ LIBPATHS =
 #	NOT auto-included here.
 SYSTEM_INCLUDE_PATHS = /boot/system/develop/headers/private/media \
 					   /boot/system/develop/headers/private/media/experimental \
-					   /boot/system/develop/headers/private/shared
+					   /boot/system/develop/headers/private/shared \
+					   /boot/system/develop/headers/private/netservices
 
 #	Additional paths paths to look for local headers. These use the form
 #	#include "header". Directories that contain the files in SRCS are
@@ -114,7 +115,7 @@ LOCALES = ca de en_GB en es ro
 #	use. For example, setting DEFINES to "DEBUG=1" will cause the compiler
 #	option "-DDEBUG=1" to be used. Setting DEFINES to "DEBUG" would pass
 #	"-DDEBUG" on the compiler's command line.
-DEFINES =
+DEFINES = LIBNETAPI_DEPRECATED
 
 #	Specify the warning level. Either NONE (suppress all warnings),
 #	ALL (enable all warnings), or leave blank (enable default warnings).

--- a/Station.cpp
+++ b/Station.cpp
@@ -503,18 +503,18 @@ Station::Load(BString name, BEntry* entry)
 		archive.Unflatten(archiveBuffer);
 		free(archiveBuffer);
 		station->fLogo = (BBitmap*) BBitmap::Instantiate(&archive);
-	} else
+	} else {
 		station->fLogo = new BBitmap(BRect(0, 0, 32, 32), B_RGB32);
-
-	status = stationInfo.GetIcon(station->fLogo, B_LARGE_ICON);
-	if (status != B_OK)
-		delete station->fLogo;
-
-	station->fLogo = new BBitmap(BRect(0, 0, 16, 16), B_RGB32);
-	status = stationInfo.GetIcon(station->fLogo, B_MINI_ICON);
-	if (status != B_OK) {
-		delete station->fLogo;
-		station->fLogo = NULL;
+		status = stationInfo.GetIcon(station->fLogo, B_LARGE_ICON);
+		if (status != B_OK) {
+			delete station->fLogo;
+			station->fLogo = new BBitmap(BRect(0, 0, 16, 16), B_RGB32);
+			status = stationInfo.GetIcon(station->fLogo, B_MINI_ICON);
+			if (status != B_OK) {
+				delete station->fLogo;
+				station->fLogo = NULL;
+			}
+		}
 	}
 
 	if (!station->fSource.IsValid()) {

--- a/StationFinderRadioNetwork.cpp
+++ b/StationFinderRadioNetwork.cpp
@@ -169,7 +169,7 @@ StationFinderRadioNetwork::FindBy(int capabilityIndex, const char* searchFor,
 
 				station->SetUniqueIdentifier(stationMessage.GetString(
 					"stationuuid", B_EMPTY_STRING));
-
+					
 				station->SetName(stationMessage.GetString("name", "unknown"));
 
 				station->SetSource(stationMessage.GetString("url",
@@ -180,8 +180,10 @@ StationFinderRadioNetwork::FindBy(int capabilityIndex, const char* searchFor,
 
 				BString iconUrl;
 				if (stationMessage.FindString("favicon", &iconUrl) == B_OK) {
-					fIconLookupList.AddItem(
-						new IconLookup(station, BUrl(iconUrl)));
+					if (!iconUrl.IsEmpty()) {
+						fIconLookupList.AddItem(
+							new IconLookup(station, BUrl(iconUrl)));
+					}
 				}
 
 				station->SetGenre(stationMessage.GetString("tags",

--- a/StreamPlayer.cpp
+++ b/StreamPlayer.cpp
@@ -54,7 +54,7 @@ StreamPlayer::StreamPlayer(Station* station, BLooper* notify)
 
 StreamPlayer::~StreamPlayer()
 {
-	_SetState(StreamPlayer::Stopped);
+	//_SetState(StreamPlayer::Stopped);
 	if (fInitStatus == B_OK && fPlayer != NULL)
 		fPlayer->Stop(true, false);
 


### PR DESCRIPTION
The network API has changed a couple of weeks ago. As a result, StreamRadio wasn't compiling anymore, at least on hrev54958, These changes allow StreamRadio to compile again, and, as a bonus, restore the radio search functionality that we missed at some point (using the package from Haiku Depot on hrev54598, at least).

While testing the app, I've discovered that it had a crash every time it tried to download a non-existent icon. The minor fix just checks if the BString that holds the icon URL is empty before proceeding with the download.

I've just realized that there's another PR waiting to be merged, but it seems that we didn't duplicate efforts and that one addresses different problems.