### PR TITLE
Fix crash when closing Find stations window

### DIFF
--- a/source/StationFinderRadioNetwork.h
+++ b/source/StationFinderRadioNetwork.h
@@ -46,6 +46,7 @@ public:
 private:
 	static	int32				_IconLookupFunc(void* data);
 			status_t			_CheckServer();
+			void				_WaitForIconLookupThread();
 
 private:
 	static	const char*			kBaseUrl;


### PR DESCRIPTION
The icon lookup thread may be running, making its `_this` invalid.