### PR TITLE
Wrapper class to fix BUrl compatibility issues

### DIFF
--- a/source/HttpUtils.cpp
+++ b/source/HttpUtils.cpp
@@ -62,7 +62,7 @@ private:
  * Loops on the DNS responses looking for connectivity on specified port.
  */
 status_t
-HttpUtils::CheckPort(BUrl url, BUrl* newUrl, uint32 flags)
+HttpUtils::CheckPort(BUrl url, MyUrl* newUrl, uint32 flags)
 {
 	uint16 port;
 	if (url.HasPort())

--- a/source/HttpUtils.h
+++ b/source/HttpUtils.h
@@ -24,12 +24,65 @@
 #include <StringList.h>
 #include <Url.h>
 
+
+// Wrapper class to ensure compatibility with old and new versions of the BUrl API
+// Make sure to properly encode URLs as needed.
+class MyUrl: public BUrl
+{
+	public:
+	MyUrl()
+		: BUrl()
+	{
+	}
+
+	MyUrl(const BUrl& base, const BString& relative)
+		: BUrl(base, relative)
+	{
+	}
+
+#if B_HAIKU_VERSION < B_HAIKU_VERSION_1_BETA_6
+	MyUrl(const BUrl& other)
+		: BUrl(other)
+	{
+	}
+
+	MyUrl(const char* string)
+		: BUr(string)
+	{
+		UrlEncode();
+	}
+
+	void SetUrlString(const char* string)
+	{
+		BUrl::SetUrlString(string);
+		UrlEncode();
+	}
+#else
+	MyUrl(const BUrl& other)
+		: BUrl(other)
+	{
+	}
+
+	MyUrl(const char* string)
+		: BUrl(string, true)
+	{
+	}
+
+	void SetUrlString(const char* string)
+	{
+		BUrl::SetUrlString(string, true);
+	}
+#endif
+};
+
+
+
 using namespace BPrivate::Network;
 
 
 class HttpUtils {
 public:
-	static status_t CheckPort(BUrl url, BUrl* newUrl, uint32 flags = 0);
+	static status_t CheckPort(BUrl url, MyUrl* newUrl, uint32 flags = 0);
 
 	static BMallocIO* GetAll(BUrl url, BHttpHeaders* returnHeaders = NULL, bigtime_t timeOut = 3000,
 		BString* contentType = NULL, size_t sizeLimit = 0);

--- a/source/MainWindow.cpp
+++ b/source/MainWindow.cpp
@@ -322,9 +322,15 @@ MainWindow::MessageReceived(BMessage* message)
 
 		case MSG_HELP:
 		{
+#if B_HAIKU_VERSION < B_HAIKU_VERSION_R1_BETA_6
 			BUrl userguide = BUrl(
 				"https://github.com/HaikuArchives/"
 				"StreamRadio/blob/master/docs/userguide.md");
+#else
+			BUrl userguide = BUrl(
+				"https://github.com/HaikuArchives/"
+				"StreamRadio/blob/master/docs/userguide.md", true);
+#endif
 			userguide.OpenWithPreferredApplication(true);
 
 			break;

--- a/source/Station.cpp
+++ b/source/Station.cpp
@@ -275,7 +275,7 @@ Station::Probe()
 	if (fStreamUrl.Protocol() == "https") {
 		buffer = HttpUtils::GetAll(fStreamUrl, &headers, 2 * 1000 * 1000, &contentType, 4096);
 	} else {
-		BUrl resolvedUrl;
+		MyUrl resolvedUrl;
 		status_t resolveStatus = HttpUtils::CheckPort(fStreamUrl, &resolvedUrl);
 		if (resolveStatus != B_OK)
 			return B_ERROR;
@@ -399,7 +399,7 @@ Station::ParseUrlReference(const char* body, const BUrl& baseUrl)
 	for (int32 i = 0; i < 3; i++) {
 		char* match = RegFind(body, patterns[i]);
 		if (match != NULL) {
-			fStreamUrl = BUrl(baseUrl, match);
+			fStreamUrl = MyUrl(baseUrl, match);
 			free(match);
 
 			match = RegFind(body, patterns[3]);
@@ -555,7 +555,7 @@ Station::RegFind(const char* text, const char* pattern)
 Station*
 Station::LoadIndirectUrl(BString& shoutCastUrl)
 {
-	BUrl url(shoutCastUrl);
+	MyUrl url(shoutCastUrl);
 	if (!url.IsValid())
 		return NULL;
 
@@ -599,7 +599,7 @@ Station::LoadIndirectUrl(BString& shoutCastUrl)
 	 *  Check for name and logo on same server by calling main page
 	 */
 
-	BUrl finalUrl = station->fStationUrl;
+	MyUrl finalUrl(station->fStationUrl);
 	if ((!finalUrl.HasPort() || finalUrl.Port() == 80)
 		&& (!finalUrl.HasPath() || finalUrl.Path().IsEmpty() || finalUrl.Path() == "/")) {
 		if (station->fName.IsEmpty())

--- a/source/Station.h
+++ b/source/Station.h
@@ -73,7 +73,7 @@ public:
 		fUnsaved = true;
 	}
 
-	inline BUrl StationUrl() { return fStationUrl; }
+	inline MyUrl StationUrl() { return fStationUrl; }
 	inline void SetStation(BUrl url)
 	{
 		fStationUrl = url;
@@ -149,12 +149,12 @@ protected:
 	void CleanName();
 
 	BString fName;
-	BUrl fStreamUrl;
-	BUrl fStationUrl;
+	MyUrl fStreamUrl;
+	MyUrl fStationUrl;
 	BString fGenre;
 	BString fCountry;
 	BString fLanguage;
-	BUrl fSource;
+	MyUrl fSource;
 	BMimeType fMime;
 	uint32 fEncoding;
 	BBitmap* fLogo;

--- a/source/StationFinder.h
+++ b/source/StationFinder.h
@@ -118,7 +118,7 @@ public:
 protected:
 	// To be filled by specific StationFinder implementations
 	BString serviceName;
-	BUrl serviceHomePage;
+	MyUrl serviceHomePage;
 	BBitmap* serviceLogo;
 #if B_HAIKU_VERSION > B_HAIKU_VERSION_1_BETA_5
 	BObjectList<FindByCapability, true> findByCapabilities;

--- a/source/StationFinderListenLive.cpp
+++ b/source/StationFinderListenLive.cpp
@@ -174,7 +174,7 @@ StationFinderListenLive::FindBy(
 	BString path(keywordAndPaths->StringAt(keywordIndex));
 	path.Remove(0, path.FindFirst('|') + 1);
 	urlString << path << ".html";
-	BUrl url(urlString);
+	MyUrl url(urlString);
 
 	BMallocIO* data = HttpUtils::GetAll(url);
 	if (data != NULL) {
@@ -261,10 +261,10 @@ StationFinderListenLive::ParseCountryReturn(BMallocIO* data, const char* searchF
 
 		BString source(doc + matches[5].rm_so);
 		if (source.EndsWith(".pls") || source.EndsWith(".m3u")) {
-			station->SetSource(BUrl(source));
+			station->SetSource(MyUrl(source));
 			fPlsLookupList.AddItem(station);
 		} else
-			station->SetStreamUrl(BUrl(source));
+			station->SetStreamUrl(MyUrl(source));
 
 		for (int32 i = matches[6].rm_so; i < matches[6].rm_eo; i++) {
 			if (!strchr("0123456789.", doc[i])) {
@@ -359,10 +359,10 @@ StationFinderListenLive::ParseGenreReturn(BMallocIO* data, const char* searchFor
 
 		BString source(doc + matches[6].rm_so);
 		if (source.EndsWith(".pls") || source.EndsWith(".m3u")) {
-			station->SetSource(BUrl(source));
+			station->SetSource(MyUrl(source));
 			fPlsLookupList.AddItem(station);
 		} else
-			station->SetStreamUrl(BUrl(source));
+			station->SetStreamUrl(MyUrl(source));
 
 		for (int32 i = matches[7].rm_so; i < matches[7].rm_eo; i++) {
 			if (!strchr("0123456789.", doc[i])) {

--- a/source/StationFinderRadioNetwork.cpp
+++ b/source/StationFinderRadioNetwork.cpp
@@ -148,7 +148,7 @@ StationFinderRadioNetwork::FindBy(
 	BString searchForString(searchFor);
 	searchForString = BUrl::UrlEncode(searchForString, true, true);
 	urlString.Append(searchForString);
-	BUrl finalUrl(urlString);
+	MyUrl finalUrl(urlString);
 
 	BMessage parsedData;
 	BMallocIO* data = HttpUtils::GetAll(finalUrl);
@@ -179,7 +179,7 @@ StationFinderRadioNetwork::FindBy(
 				BString iconUrl;
 				if (stationMessage.FindString("favicon", &iconUrl) == B_OK) {
 					if (!iconUrl.IsEmpty()) {
-						fIconLookupList.AddItem(new IconLookup(station, BUrl(iconUrl)));
+						fIconLookupList.AddItem(new IconLookup(station, MyUrl(iconUrl)));
 					}
 				}
 
@@ -251,7 +251,7 @@ status_t
 StationFinderRadioNetwork::_CheckServer()
 {
 	// Just a quick check up on our cached server...if it exists.
-	BUrl cachedServerUrl(sCachedServerUrl);
+	MyUrl cachedServerUrl(sCachedServerUrl);
 	if (!sCachedServerUrl.IsEmpty()
 		&& HttpUtils::CheckPort(cachedServerUrl, &cachedServerUrl, 0) == B_OK) {
 		// It's still there!
@@ -259,7 +259,7 @@ StationFinderRadioNetwork::_CheckServer()
 	}
 
 	// Try to find an active server!
-	BUrl testServerUrl(kBaseUrl);
+	MyUrl testServerUrl(kBaseUrl);
 	status_t result = HttpUtils::CheckPort(testServerUrl, &testServerUrl, 0);
 	if (result != B_OK) {
 		// Oh no...this is, uh, pretty bad.

--- a/source/StationPanel.cpp
+++ b/source/StationPanel.cpp
@@ -216,7 +216,7 @@ StationPanel::MessageReceived(BMessage* msg)
 					BString search;
 					search.SetToFormat("https://google.com/search?q=%s",
 						BUrl::UrlEncode(*station->Name()).String());
-					BUrl searchUrl(search);
+					MyUrl searchUrl(search);
 					searchUrl.OpenWithPreferredApplication(false);
 				} else
 					station->StationUrl().OpenWithPreferredApplication(false);

--- a/source/StreamIO.cpp
+++ b/source/StreamIO.cpp
@@ -82,7 +82,7 @@ StreamIO::StreamIO(Station* station, BLooper* metaListener)
 		fReq = dynamic_cast<BHttpRequest*>(
 			BUrlProtocolRoster::MakeRequest(url.UrlString().String(), this, this));
 	} else {
-		BUrl* newUrl = new BUrl();
+		MyUrl* newUrl = new MyUrl();
 		if (newUrl == NULL)
 			return;
 


### PR DESCRIPTION
Suggested fix for #70

@korli do you think this approach is OK to enclose source compatibility issues in a single class? It also makes sure the URL is encoded in the same way on all versions, so that should avoid unexpected changes of behavior.

Note: I wrote this in a train with spotty internet connection and I have no soundcard on this Haiku machine, so this is not fully tested.